### PR TITLE
Update signal1d.rst

### DIFF
--- a/doc/user_guide/signal1d.rst
+++ b/doc/user_guide/signal1d.rst
@@ -14,7 +14,7 @@ In addition to cropping using the powerful and compact :ref:`Signal indexing
 <signal.indexing>` syntax the following method is available to crop spectra
 using a GUI:
 
-The :py:meth:`~.signal.Signal1DTools.crop_signal1D`, method is used to crop the
+The :py:meth:`~.signal.Signal1D.crop_signal1D`, method is used to crop the
 spectral energy range. If no parameter is passed, a user interface appears in
 which to crop the one dimensional signal.
 


### PR DESCRIPTION
A number of links to the detailed command descriptions are broken. I don't know if this is a known issue. For example, in this section (Signal1D tools) only the spikes removal tool link actually works. I think it may be due to the presence of a thing called "Signal1DTools" which no longer exists. Singal1D does exist so I'm trying it here. If I'm right I'll do the others but I don't know how to test links within the documentation before I do a pull request, so I need confirmation.
Thanks